### PR TITLE
Clean up SQLite additions

### DIFF
--- a/src/main/java/me/glaremasters/guilds/database/DatabaseManager.java
+++ b/src/main/java/me/glaremasters/guilds/database/DatabaseManager.java
@@ -14,22 +14,29 @@ public class DatabaseManager {
     public DatabaseManager(SettingsManager settingsManager, DatabaseBackend backend) {
         HikariConfig config = new HikariConfig();
 
-        // todo check for sqlite datasource somehow and then make sure it uses the db file
-        if (backend == DatabaseBackend.MYSQL) {
-            config.setPoolName("Guilds Connection Pool");
-            config.setDataSourceClassName(settingsManager.getProperty(StorageSettings.DATASOURCE));
-            config.addDataSourceProperty("serverName", settingsManager.getProperty(StorageSettings.SQL_HOST));
-            config.addDataSourceProperty("port", settingsManager.getProperty(StorageSettings.SQL_PORT));
-            config.addDataSourceProperty("databaseName", settingsManager.getProperty(StorageSettings.SQL_DATABASE));
-            config.addDataSourceProperty("user", settingsManager.getProperty(StorageSettings.SQL_USERNAME));
-            config.addDataSourceProperty("password", settingsManager.getProperty(StorageSettings.SQL_PASSWORD));
-            config.addDataSourceProperty("useSSL", settingsManager.getProperty(StorageSettings.SQL_ENABLE_SSL));
-            config.setMaximumPoolSize(settingsManager.getProperty(StorageSettings.SQL_POOL_SIZE));
-            config.setMinimumIdle(settingsManager.getProperty(StorageSettings.SQL_POOL_IDLE));
-            config.setMaxLifetime(settingsManager.getProperty(StorageSettings.SQL_POOL_LIFETIME));
-            config.setConnectionTimeout(settingsManager.getProperty(StorageSettings.SQL_POOL_TIMEOUT));
-        } else {
-            config.setJdbcUrl("jdbc:sqlite:plugins/Guilds/" + settingsManager.getProperty(StorageSettings.SQL_DATABASE) + ".db");
+        config.setPoolName("Guilds Connection Pool");
+        config.setDataSourceClassName(settingsManager.getProperty(StorageSettings.DATASOURCE));
+        config.setMaximumPoolSize(settingsManager.getProperty(StorageSettings.SQL_POOL_SIZE));
+        config.setMinimumIdle(settingsManager.getProperty(StorageSettings.SQL_POOL_IDLE));
+        config.setMaxLifetime(settingsManager.getProperty(StorageSettings.SQL_POOL_LIFETIME));
+        config.setConnectionTimeout(settingsManager.getProperty(StorageSettings.SQL_POOL_TIMEOUT));
+
+        String databaseName = settingsManager.getProperty(StorageSettings.SQL_DATABASE);
+
+        switch (backend) {
+            case MYSQL:
+                config.addDataSourceProperty("serverName", settingsManager.getProperty(StorageSettings.SQL_HOST));
+                config.addDataSourceProperty("port", settingsManager.getProperty(StorageSettings.SQL_PORT));
+                config.addDataSourceProperty("databaseName", databaseName);
+                config.addDataSourceProperty("user", settingsManager.getProperty(StorageSettings.SQL_USERNAME));
+                config.addDataSourceProperty("password", settingsManager.getProperty(StorageSettings.SQL_PASSWORD));
+                config.addDataSourceProperty("useSSL", settingsManager.getProperty(StorageSettings.SQL_ENABLE_SSL));
+                break;
+            case SQLITE:
+                config.setJdbcUrl(String.format("jdbc:sqlite:plugins/Guilds/%s.db", databaseName));
+                break;
+            default:
+                throw new IllegalArgumentException("Invalid backend for DatabaseManager setup: " + backend.getBackendName());
         }
 
         HikariDataSource hikari;

--- a/src/main/java/me/glaremasters/guilds/database/guild/GuildAdapter.java
+++ b/src/main/java/me/glaremasters/guilds/database/guild/GuildAdapter.java
@@ -25,9 +25,6 @@ public class GuildAdapter {
                 provider = new GuildJsonProvider(fileDataFolder);
                 break;
             case MYSQL:
-                sqlTablePrefix = adapter.getSqlTablePrefix();
-                provider = adapter.getDatabaseManager().getJdbi().onDemand(backend.getGuildProvider());
-                break;
             case SQLITE:
                 sqlTablePrefix = adapter.getSqlTablePrefix();
                 provider = adapter.getDatabaseManager().getJdbi().onDemand(backend.getGuildProvider());


### PR DESCRIPTION
Change `DatabaseManager` to use a switch on backend type, default to `IllegalArgumentException` (it would be a bug if `DatabaseManager` is created for anything but `MYSQL`/`SQLITE` at the moment). Extract common settings/properties from `MYSQL` branch in `DatabaseManager`. Let `MYSQL` branch fall through to `SQLITE` in `GuildAdapter` to stop repeating assignments.