### PR TITLE
Fix migrate command

### DIFF
--- a/src/main/java/me/glaremasters/guilds/Guilds.java
+++ b/src/main/java/me/glaremasters/guilds/Guilds.java
@@ -264,7 +264,7 @@ public final class Guilds extends JavaPlugin {
             // Load the challenge provider
             challengesProvider = new ChallengesProvider(this);
             // Load guildhandler with provider
-            guildHandler = new GuildHandler(database, getCommandManager(), getPermissions(), getConfig(), settingsHandler.getSettingsManager());
+            guildHandler = new GuildHandler(this, getCommandManager(), getPermissions(), getConfig(), settingsHandler.getSettingsManager());
             LoggingUtils.info("Loaded data!");
         } catch (IOException e) {
             LoggingUtils.severe("An error occurred loading data! Stopping plugin..");

--- a/src/main/java/me/glaremasters/guilds/configuration/sections/StorageSettings.java
+++ b/src/main/java/me/glaremasters/guilds/configuration/sections/StorageSettings.java
@@ -13,11 +13,6 @@ public class StorageSettings implements SettingsHolder {
     public static final Property<String> STORAGE_TYPE =
             newProperty("storage.storage-type", "json");
 
-    @Comment({"Which datasource should be used? Use the correct one for each database",
-            "MySQL: com.mysql.jdbc.jdbc2.optional.MysqlDataSource"})
-    public static final Property<String> DATASOURCE =
-            newProperty("storage.datasource", "com.mysql.jdbc.jdbc2.optional.MysqlDataSource");
-
     @Comment({"How often (in minutes) do you want all Guild Data to save?"})
     public static final Property<Integer> SAVE_INTERVAL =
             newProperty("storage.save-interval", 1);

--- a/src/main/java/me/glaremasters/guilds/database/DatabaseManager.java
+++ b/src/main/java/me/glaremasters/guilds/database/DatabaseManager.java
@@ -23,7 +23,7 @@ public class DatabaseManager {
         switch (backend) {
             case MYSQL:
                 config.setPoolName("Guilds MySQL Connection Pool");
-                config.setDataSourceClassName(settingsManager.getProperty(StorageSettings.DATASOURCE));
+                config.setDataSourceClassName("com.mysql.jdbc.jdbc2.optional.MysqlDataSource");
                 config.addDataSourceProperty("serverName", settingsManager.getProperty(StorageSettings.SQL_HOST));
                 config.addDataSourceProperty("port", settingsManager.getProperty(StorageSettings.SQL_PORT));
                 config.addDataSourceProperty("databaseName", databaseName);

--- a/src/main/java/me/glaremasters/guilds/database/DatabaseManager.java
+++ b/src/main/java/me/glaremasters/guilds/database/DatabaseManager.java
@@ -14,7 +14,6 @@ public class DatabaseManager {
     public DatabaseManager(SettingsManager settingsManager, DatabaseBackend backend) {
         HikariConfig config = new HikariConfig();
 
-        config.setPoolName("Guilds Connection Pool");
         config.setMaximumPoolSize(settingsManager.getProperty(StorageSettings.SQL_POOL_SIZE));
         config.setMinimumIdle(settingsManager.getProperty(StorageSettings.SQL_POOL_IDLE));
         config.setMaxLifetime(settingsManager.getProperty(StorageSettings.SQL_POOL_LIFETIME));
@@ -23,6 +22,7 @@ public class DatabaseManager {
         String databaseName = settingsManager.getProperty(StorageSettings.SQL_DATABASE);
         switch (backend) {
             case MYSQL:
+                config.setPoolName("Guilds MySQL Connection Pool");
                 config.setDataSourceClassName(settingsManager.getProperty(StorageSettings.DATASOURCE));
                 config.addDataSourceProperty("serverName", settingsManager.getProperty(StorageSettings.SQL_HOST));
                 config.addDataSourceProperty("port", settingsManager.getProperty(StorageSettings.SQL_PORT));
@@ -32,6 +32,7 @@ public class DatabaseManager {
                 config.addDataSourceProperty("useSSL", settingsManager.getProperty(StorageSettings.SQL_ENABLE_SSL));
                 break;
             case SQLITE:
+                config.setPoolName("Guilds SQLite Connection Pool");
                 config.setJdbcUrl(String.format("jdbc:sqlite:plugins/Guilds/%s.db", databaseName));
                 break;
             default:

--- a/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
+++ b/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
@@ -72,15 +72,15 @@ public class GuildHandler {
     private Map<Guild, List<Inventory>> cachedVaults;
     private List<Player> openedVault;
 
-    private final DatabaseAdapter databaseProvider;
+    private final Guilds guildsPlugin;
     private final CommandManager commandManager;
     private final Permission permission;
     private final SettingsManager settingsManager;
 
     //as well as guild permissions from tiers using permission field and tiers list.
 
-    public GuildHandler(DatabaseAdapter databaseProvider, CommandManager commandManager, Permission permission, FileConfiguration config, SettingsManager settingsManager) {
-        this.databaseProvider = databaseProvider;
+    public GuildHandler(Guilds guildsPlugin, CommandManager commandManager, Permission permission, FileConfiguration config, SettingsManager settingsManager) {
+        this.guildsPlugin = guildsPlugin;
         this.commandManager = commandManager;
         this.permission = permission;
         this.settingsManager = settingsManager;
@@ -154,7 +154,7 @@ public class GuildHandler {
 
         Guilds.newChain().async(() -> {
             try {
-                guilds = databaseProvider.getGuildAdapter().getAllGuilds();
+                guilds = guildsPlugin.getDatabase().getGuildAdapter().getAllGuilds();
             } catch (IOException e) {
                 e.printStackTrace();
             }
@@ -170,7 +170,7 @@ public class GuildHandler {
      */
     public void saveData() throws IOException {
         guilds.forEach(this::saveVaultCache);
-        databaseProvider.getGuildAdapter().saveGuilds(guilds);
+        guildsPlugin.getDatabase().getGuildAdapter().saveGuilds(guilds);
     }
 
 


### PR DESCRIPTION
Connection pool names were clashing during migrate command, use different names while two pools exist.

After migrating, `GuildHandler` still held a reference to the now-closed adapter. To fix this, `GuildHandler` now just has to read from the main class. This will ensure the `GuildHandler` always has a valid reference to the db.