### PR TITLE
World whitelist and DXL support

### DIFF
--- a/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
+++ b/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
@@ -29,9 +29,12 @@ import co.aikar.commands.ACFBukkitUtil;
 import co.aikar.commands.CommandManager;
 import me.glaremasters.guilds.Guilds;
 import me.glaremasters.guilds.arena.Arena;
+import me.glaremasters.guilds.configuration.sections.GuildSettings;
+import me.glaremasters.guilds.configuration.sections.HooksSettings;
 import me.glaremasters.guilds.configuration.sections.WarSettings;
 import me.glaremasters.guilds.guild.Guild;
 import me.glaremasters.guilds.guild.GuildChallenge;
+import me.glaremasters.guilds.guild.GuildHandler;
 import me.glaremasters.guilds.guild.GuildMember;
 import me.glaremasters.guilds.messages.Messages;
 import org.apache.commons.collections4.map.LinkedMap;
@@ -56,8 +59,10 @@ import java.util.stream.Stream;
  */
 public class ChallengeHandler {
 
+    private GuildHandler guildHandler;
     private List<GuildChallenge> challenges;
     private Guilds guilds;
+    private SettingsManager settingsManager;
 
     public ChallengeHandler(Guilds guilds) {
         this.guilds = guilds;
@@ -204,10 +209,21 @@ public class ChallengeHandler {
         LinkedMap<UUID, String> finalList = new LinkedMap<>();
         players.forEach(p -> {
             Player player = Bukkit.getPlayer(p);
+            if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
+                &&
+                !player.getWorld().toString().contains("DXL_Game_"))
+                return;
+
+            if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
+                &&
+                !guildHandler.getWorldWhitelist().contains(player.getWorld()))
+                return;
+
             if (player != null) {
                 finalList.putIfAbsent(p, ACFBukkitUtil.fullLocationToString(player.getLocation()));
             }
         });
+
         if (team.equalsIgnoreCase("challenger")) {
             challenge.setAliveChallengers(finalList);
         } else {

--- a/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
+++ b/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
@@ -211,7 +211,7 @@ public class ChallengeHandler {
             Player player = Bukkit.getPlayer(p);
             if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
                 &&
-                player.getWorld().toString().contains("DXL_Game_"))
+                player.getWorld().toString().startsWith("DXL_"))
                 return;
 
             if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)

--- a/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
+++ b/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
@@ -223,7 +223,6 @@ public class ChallengeHandler {
                 finalList.putIfAbsent(p, ACFBukkitUtil.fullLocationToString(player.getLocation()));
             }
         });
-
         if (team.equalsIgnoreCase("challenger")) {
             challenge.setAliveChallengers(finalList);
         } else {

--- a/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
+++ b/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
@@ -211,12 +211,12 @@ public class ChallengeHandler {
             Player player = Bukkit.getPlayer(p);
             if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
                 &&
-                !player.getWorld().toString().contains("DXL_Game_"))
+                player.getWorld().toString().contains("DXL_Game_"))
                 return;
 
             if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
                 &&
-                !guildHandler.getWorldWhitelist().contains(player.getWorld()))
+                !guildHandler.getWorldsWhitelist().contains(player.getWorld()))
                 return;
 
             if (player != null) {

--- a/src/main/java/me/glaremasters/guilds/configuration/sections/GuildSettings.java
+++ b/src/main/java/me/glaremasters/guilds/configuration/sections/GuildSettings.java
@@ -113,14 +113,22 @@ public class GuildSettings implements SettingsHolder {
     @Comment({"Do we want to respect WorldGuard flags for PVP deny?",
             "This will be checked first before checking same guild and ally.",
             "This is ONLY needed if you have either of the above two options to set true.",
-    "ONLY PUT THIS ON TRUE IF YOU HAVE WORLDGUARD INSTALLED OR YOU WILL BREAK STUFF"})
+            "ONLY PUT THIS ON TRUE IF YOU HAVE WORLDGUARD INSTALLED OR YOU WILL BREAK STUFF"})
     public static final Property<Boolean> RESPECT_WG_PVP_FLAG =
             newProperty("guild.damage.respect-wg-pvp-flag", false);
 
     @Comment("Would you like to send players their guild's motd on login?")
     public static final Property<Boolean> MOTD_ON_LOGIN =
             newProperty("guild.motd-on-login", true);
+    
+    @Comment({"Do we want to enable world whitelist?",
+            "This allows PvP between allies, disabled buffs and cancels teleportation to war in worlds that are not listed."})
+    public static final Property<Boolean> WORLDS_WHITELIST_TOGGLE =
+            newProperty("guild.world-whitelist.enabled", false);
 
+    @Comment("What worlds would you like to whitelisted")
+    public static final Property<List<String>> WHITELIST_WORLDS =
+            newListProperty("guild.world-whitelist.worlds", "world", "world_nether", "world_the_end");
 
     private GuildSettings() {
     }

--- a/src/main/java/me/glaremasters/guilds/configuration/sections/HooksSettings.java
+++ b/src/main/java/me/glaremasters/guilds/configuration/sections/HooksSettings.java
@@ -45,6 +45,11 @@ public class HooksSettings implements SettingsHolder {
     public static final Property<Boolean> WORLDGUARD =
             newProperty("hooks.worldguard-claims", false);
 
+    @Comment({"Do we want to hook into DungeonsXL?",
+            "This allows PvP between allies, disabled buffs and cancels teleportation to war in DungneonsXL games."})
+    public static final Property<Boolean> DUNGEONSXL =
+            newProperty("hooks.dugeonsxl", false);
+
     private HooksSettings() {
     }
 }

--- a/src/main/java/me/glaremasters/guilds/guild/Guild.java
+++ b/src/main/java/me/glaremasters/guilds/guild/Guild.java
@@ -26,6 +26,8 @@ package me.glaremasters.guilds.guild;
 
 import co.aikar.commands.ACFUtil;
 import co.aikar.commands.CommandManager;
+import me.glaremasters.guilds.configuration.sections.GuildSettings;
+import me.glaremasters.guilds.configuration.sections.HooksSettings;
 import me.glaremasters.guilds.exceptions.ExpectationNotMet;
 import me.glaremasters.guilds.messages.Messages;
 import me.glaremasters.guilds.utils.SkullUtils;
@@ -37,12 +39,18 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
+import ch.jalu.configme.SettingsManager;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class Guild {
+    
+    private GuildHandler guildHandler;
+    private SettingsManager settingsManager;
 
     public Guild(UUID id) {
         this.id = id;
@@ -532,13 +540,30 @@ public class Guild {
     }
 
     /**
+     * Get available online players
+     * including world check if enabled
+     * @return list available for buff players
+     */
+    public List<Player> availablePlayers() {
+        return getOnlineAsPlayers().stream().filter(p -> !
+            ((settingsManager.getProperty(HooksSettings.DUNGEONSXL)
+            &&
+            !p.getWorld().toString().contains("DXL_World_"))
+        ||
+            (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
+            &&
+            !guildHandler.getWorldWhitelist().contains(p.getWorld()))))
+        .collect(Collectors.toList());
+    }
+
+    /**
      * Simple method to add a buff to all online members
      * @param type the potion type
      * @param length the length of the potion
      * @param amplifier the strength of the potion
      */
     public void addPotion(String type, int length, int amplifier) {
-        getOnlineAsPlayers().forEach(p -> p.addPotionEffect(new PotionEffect(PotionEffectType.getByName(type), length, amplifier)));
+        availablePlayers().forEach(p -> p.addPotionEffect(new PotionEffect(PotionEffectType.getByName(type), length, amplifier)));
     }
 
     public UUID getId() {

--- a/src/main/java/me/glaremasters/guilds/guild/Guild.java
+++ b/src/main/java/me/glaremasters/guilds/guild/Guild.java
@@ -552,7 +552,7 @@ public class Guild {
         ||
             (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
             &&
-            !guildHandler.getWorldWhitelist().contains(p.getWorld()))))
+            !guildHandler.getWorldsWhitelist().contains(p.getWorld()))))
         .collect(Collectors.toList());
     }
 

--- a/src/main/java/me/glaremasters/guilds/guild/Guild.java
+++ b/src/main/java/me/glaremasters/guilds/guild/Guild.java
@@ -548,7 +548,7 @@ public class Guild {
         return getOnlineAsPlayers().stream().filter(p -> !
             ((settingsManager.getProperty(HooksSettings.DUNGEONSXL)
             &&
-            !p.getWorld().toString().contains("DXL_World_"))
+            p.getWorld().toString().contains("DXL_World_"))
         ||
             (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
             &&

--- a/src/main/java/me/glaremasters/guilds/guild/Guild.java
+++ b/src/main/java/me/glaremasters/guilds/guild/Guild.java
@@ -24,6 +24,7 @@
 
 package me.glaremasters.guilds.guild;
 
+import ch.jalu.configme.SettingsManager;
 import co.aikar.commands.ACFUtil;
 import co.aikar.commands.CommandManager;
 import me.glaremasters.guilds.configuration.sections.GuildSettings;
@@ -39,16 +40,13 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-import ch.jalu.configme.SettingsManager;
-
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 public class Guild {
-    
+
     private GuildHandler guildHandler;
     private SettingsManager settingsManager;
 

--- a/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
+++ b/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
@@ -952,7 +952,11 @@ public class GuildHandler {
         }
         return ACFBukkitUtil.color(combined.replace("{name}", guild.getName()).replace("{prefix}", guild.getPrefix()));
     }
-    
+
+    /**
+     * Get whitelisted worlds
+     * @return world list
+     */
     public List<World> getWorldWhitelist() {
         for (String world : settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS)) {
             world.split(",");

--- a/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
+++ b/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
@@ -955,14 +955,10 @@ public class GuildHandler {
 
     /**
      * Get whitelisted worlds
-     * @return world list
+     * @return worlds list
      */
-    public List<World> getWorldWhitelist() {
-        for (String world : settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS)) {
-            world.split(",");
-            worldWhiteList.add(Bukkit.getWorld(world));
-        }
-        return worldWhiteList;
+    public List<World> getWorldsWhitelist() {
+        return settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS).stream().map(m -> Bukkit.getWorld(m)).collect(Collectors.toList());
     }
 
     public List<Guild> getGuilds() {

--- a/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
+++ b/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
@@ -69,6 +69,7 @@ public class GuildHandler {
     private final List<GuildTier> tiers;
     private final List<Player> spies;
     private final List<Player> guildChat;
+    private final List<World> worldWhiteList;
 
     private Map<Guild, List<Inventory>> cachedVaults;
     private List<Player> openedVault;
@@ -90,6 +91,7 @@ public class GuildHandler {
         guildChat = new ArrayList<>();
         cachedVaults = new HashMap<>();
         openedVault = new ArrayList<>();
+        worldWhiteList = new ArrayList<>();
 
         migrating = false;
 
@@ -955,8 +957,13 @@ public class GuildHandler {
      * Get whitelisted worlds
      * @return worlds list
      */
+    // TODO Use Stream API
     public List<World> getWorldsWhitelist() {
-        return settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS).stream().map(m -> Bukkit.getWorld(m)).collect(Collectors.toList());
+        for (String world : settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS)) {
+            world.split(",");
+            worldWhiteList.add(Bukkit.getWorld(world));
+        }
+        return worldWhiteList;
     }
 
     public List<Guild> getGuilds() {

--- a/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
+++ b/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
@@ -42,6 +42,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.InvalidConfigurationException;
 import org.bukkit.configuration.file.YamlConfiguration;
@@ -68,6 +69,7 @@ public class GuildHandler {
     private final List<GuildTier> tiers;
     private final List<Player> spies;
     private final List<Player> guildChat;
+    private final List<World> worldWhiteList;
 
     private Map<Guild, List<Inventory>> cachedVaults;
     private List<Player> openedVault;
@@ -89,6 +91,7 @@ public class GuildHandler {
         guildChat = new ArrayList<>();
         cachedVaults = new HashMap<>();
         openedVault = new ArrayList<>();
+        worldWhiteList = new ArrayList<>();
 
         migrating = false;
 
@@ -948,6 +951,14 @@ public class GuildHandler {
             return noGuild;
         }
         return ACFBukkitUtil.color(combined.replace("{name}", guild.getName()).replace("{prefix}", guild.getPrefix()));
+    }
+    
+    public List<World> getWorldWhitelist() {
+        for (String world : settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS)) {
+            world.split(",");
+            worldWhiteList.add(Bukkit.getWorld(world));
+        }
+        return worldWhiteList;
     }
 
     public List<Guild> getGuilds() {

--- a/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
+++ b/src/main/java/me/glaremasters/guilds/guild/GuildHandler.java
@@ -69,7 +69,6 @@ public class GuildHandler {
     private final List<GuildTier> tiers;
     private final List<Player> spies;
     private final List<Player> guildChat;
-    private final List<World> worldWhiteList;
 
     private Map<Guild, List<Inventory>> cachedVaults;
     private List<Player> openedVault;
@@ -91,7 +90,6 @@ public class GuildHandler {
         guildChat = new ArrayList<>();
         cachedVaults = new HashMap<>();
         openedVault = new ArrayList<>();
-        worldWhiteList = new ArrayList<>();
 
         migrating = false;
 

--- a/src/main/java/me/glaremasters/guilds/guis/BuffGUI.java
+++ b/src/main/java/me/glaremasters/guilds/guis/BuffGUI.java
@@ -308,14 +308,14 @@ public class BuffGUI {
     }
 
     /**
-     * Execute a list of commands on all players online in a guild
+     * Execute a list of commands on all available players online in a guild
      * @param check if this can run or not
      * @param commands the commands to run
      * @param guild the guild of players to run on
      */
     private void executeGuildCommands(boolean check, List<String> commands, Guild guild) {
         if (check) {
-            guild.getOnlineAsPlayers().forEach(p -> commands.forEach(c -> {
+            guild.availablePlayers().forEach(p -> commands.forEach(c -> {
                 String update = c.replace("{player}", p.getName());
                 Bukkit.getServer().dispatchCommand(Bukkit.getConsoleSender(), update);
             }));

--- a/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
@@ -57,7 +57,7 @@ import java.util.Set;
  * Time: 5:21 PM
  */
 public class EntityListener implements Listener {
-    
+
     private GuildHandler guildHandler;
     private SettingsManager settingsManager;
     private ChallengeHandler challengeHandler;
@@ -68,7 +68,7 @@ public class EntityListener implements Listener {
         this.settingsManager = settingsManager;
         this.challengeHandler = challengeHandler;
     }
-    
+
     /**
      * Handles the extra damage to a mob
      * @param event
@@ -86,7 +86,6 @@ public class EntityListener implements Listener {
             event.setDamage(dmg * multiplier);
         }
     }
-
 
     /**
      * Handles extra XP dropped from mobs

--- a/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
@@ -123,10 +123,10 @@ public class EntityListener implements Listener {
             player.getWorld().toString().contains("DXL_Game_"))
             return;
 
-        // Check world whitelist
+        // Check worlds whitelist
         if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
             &&
-            !guildHandler.getWorldWhitelist().contains(player.getWorld()))
+            !guildHandler.getWorldsWhitelist().contains(player.getWorld()))
             return;
 
         // Make sure that they aren't in a claim that turns off pvp
@@ -187,7 +187,7 @@ public class EntityListener implements Listener {
 
         if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
             &&
-            !guildHandler.getWorldWhitelist().contains(damager.getWorld()))
+            !guildHandler.getWorldsWhitelist().contains(damager.getWorld()))
             return;
 
         if (guildHandler.isSameGuild(damagee, damager) && damagee != damager ) {
@@ -234,7 +234,7 @@ public class EntityListener implements Listener {
 
         if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
             &&
-            !guildHandler.getWorldWhitelist().contains(damager.getWorld()))
+            !guildHandler.getWorldsWhitelist().contains(damager.getWorld()))
             return;
 
         if (guildHandler.isSameGuild(damagee, damager)) {
@@ -284,7 +284,7 @@ public class EntityListener implements Listener {
 
                 if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
                     &&
-                    !guildHandler.getWorldWhitelist().contains(shooter.getWorld())) 
+                    !guildHandler.getWorldsWhitelist().contains(shooter.getWorld())) 
                     return;
                 
                 if (guildHandler.isSameGuild(shooter, player) && potion.getShooter() != player ) {

--- a/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
@@ -25,7 +25,6 @@
 package me.glaremasters.guilds.listeners;
 
 import ch.jalu.configme.SettingsManager;
-//import de.erethon.dungeonsxl.DungeonsXL;
 import me.glaremasters.guilds.challenges.ChallengeHandler;
 import me.glaremasters.guilds.configuration.sections.GuildSettings;
 import me.glaremasters.guilds.configuration.sections.HooksSettings;
@@ -34,8 +33,6 @@ import me.glaremasters.guilds.guild.GuildChallenge;
 import me.glaremasters.guilds.guild.GuildHandler;
 import me.glaremasters.guilds.utils.ClaimUtils;
 
-import org.bukkit.Bukkit;
-import org.bukkit.World;
 import org.bukkit.entity.Arrow;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Monster;
@@ -50,10 +47,8 @@ import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 /**
@@ -67,17 +62,11 @@ public class EntityListener implements Listener {
     private SettingsManager settingsManager;
     private ChallengeHandler challengeHandler;
     private final Set<PotionEffectType> bad = new HashSet<>(Arrays.asList(PotionEffectType.BLINDNESS, PotionEffectType.WITHER, PotionEffectType.SLOW_DIGGING, PotionEffectType.WEAKNESS, PotionEffectType.SLOW, PotionEffectType.POISON));
-    public List<World> worldWL = new ArrayList<World>();
 
     public EntityListener(GuildHandler guildHandler, SettingsManager settingsManager, ChallengeHandler challengeHandler) {
         this.guildHandler = guildHandler;
         this.settingsManager = settingsManager;
         this.challengeHandler = challengeHandler;
-        
-        for (String world : settingsManager.getProperty(GuildSettings.WHITELIST_WORLDS)) {
-            world.split(",");
-            worldWL.add(Bukkit.getWorld(world));
-        }
     }
     
     /**
@@ -135,7 +124,7 @@ public class EntityListener implements Listener {
 
         // Check world whitelist
         if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
-            if (!worldWL.contains(player.getWorld())) return;
+            if (!guildHandler.getWorldWhitelist().contains(player.getWorld())) return;
         }
 
 

--- a/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
@@ -118,14 +118,16 @@ public class EntityListener implements Listener {
         Player damager = (Player) event.getDamager();
         
         // Check if player in dungeon
-        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
-            if (player.getWorld().toString().contains("DXL_Game_")) return;
-        }
+        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
+            &&
+            player.getWorld().toString().contains("DXL_Game_"))
+            return;
 
         // Check world whitelist
-        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
-            if (!guildHandler.getWorldWhitelist().contains(player.getWorld())) return;
-        }
+        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
+            &&
+            !guildHandler.getWorldWhitelist().contains(player.getWorld()))
+            return;
 
         // Make sure that they aren't in a claim that turns off pvp
         if (settingsManager.getProperty(GuildSettings.RESPECT_WG_PVP_FLAG)) {
@@ -178,14 +180,15 @@ public class EntityListener implements Listener {
             return;
         }
         
-        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
-            if (damager.getWorld().toString().contains("DXL_Game_")) return;
-        }
+        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
+            &&
+            damager.getWorld().toString().contains("DXL_Game_"))
+            return;
 
-        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
-            if (!guildHandler.getWorldWhitelist().contains(damager.getWorld())) return;
-
-        }
+        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
+            &&
+            !guildHandler.getWorldWhitelist().contains(damager.getWorld()))
+            return;
 
         if (guildHandler.isSameGuild(damagee, damager) && damagee != damager ) {
             event.setCancelled(!settingsManager.getProperty(GuildSettings.GUILD_DAMAGE));
@@ -224,13 +227,15 @@ public class EntityListener implements Listener {
             return;
         }
         
-        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
-            if (damager.getWorld().toString().contains("DXL_Game_")) return;
-        }
+        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
+            &&
+            damager.getWorld().toString().contains("DXL_Game_"))
+            return;
 
-        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
-            if (!guildHandler.getWorldWhitelist().contains(damager.getWorld())) return;
-        }
+        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
+            &&
+            !guildHandler.getWorldWhitelist().contains(damager.getWorld()))
+            return;
 
         if (guildHandler.isSameGuild(damagee, damager)) {
             arrow.setFireTicks(0);
@@ -272,13 +277,15 @@ public class EntityListener implements Listener {
             if (entity instanceof Player)  {
                 Player player = (Player) entity;
                 
-                if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
-                    if (shooter.getWorld().toString().contains("DXL_Game_")) return;
-                }
+                if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
+                    &&
+                    shooter.getWorld().toString().contains("DXL_Game_"))
+                    return;
 
-                if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
-                    if (!guildHandler.getWorldWhitelist().contains(shooter.getWorld())) return;
-                }
+                if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
+                    &&
+                    !guildHandler.getWorldWhitelist().contains(shooter.getWorld())) 
+                    return;
                 
                 if (guildHandler.isSameGuild(shooter, player) && potion.getShooter() != player ) {
                     event.setCancelled(!settingsManager.getProperty(GuildSettings.GUILD_DAMAGE));

--- a/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
@@ -119,7 +119,7 @@ public class EntityListener implements Listener {
         // Check if player in dungeon
         if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
             &&
-            player.getWorld().toString().contains("DXL_Game_"))
+            player.getWorld().toString().startsWith("DXL_"))
             return;
 
         // Check worlds whitelist
@@ -181,7 +181,7 @@ public class EntityListener implements Listener {
         
         if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
             &&
-            damager.getWorld().toString().contains("DXL_Game_"))
+            damager.getWorld().toString().startsWith("DXL_"))
             return;
 
         if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
@@ -228,7 +228,7 @@ public class EntityListener implements Listener {
         
         if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
             &&
-            damager.getWorld().toString().contains("DXL_Game_"))
+            damager.getWorld().toString().startsWith("DXL_"))
             return;
 
         if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)
@@ -278,7 +278,7 @@ public class EntityListener implements Listener {
                 
                 if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)
                     &&
-                    shooter.getWorld().toString().contains("DXL_Game_"))
+                    shooter.getWorld().toString().startsWith("DXL_"))
                     return;
 
                 if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)

--- a/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/EntityListener.java
@@ -127,7 +127,6 @@ public class EntityListener implements Listener {
             if (!guildHandler.getWorldWhitelist().contains(player.getWorld())) return;
         }
 
-
         // Make sure that they aren't in a claim that turns off pvp
         if (settingsManager.getProperty(GuildSettings.RESPECT_WG_PVP_FLAG)) {
             event.setCancelled(ClaimUtils.checkPvpDisabled(player));
@@ -178,6 +177,15 @@ public class EntityListener implements Listener {
             event.setCancelled(ClaimUtils.checkPvpDisabled(damagee));
             return;
         }
+        
+        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
+            if (damager.getWorld().toString().contains("DXL_Game_")) return;
+        }
+
+        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
+            if (!guildHandler.getWorldWhitelist().contains(damager.getWorld())) return;
+
+        }
 
         if (guildHandler.isSameGuild(damagee, damager) && damagee != damager ) {
             event.setCancelled(!settingsManager.getProperty(GuildSettings.GUILD_DAMAGE));
@@ -214,6 +222,14 @@ public class EntityListener implements Listener {
         if (settingsManager.getProperty(GuildSettings.RESPECT_WG_PVP_FLAG)) {
             event.setCancelled(ClaimUtils.checkPvpDisabled(damagee));
             return;
+        }
+        
+        if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
+            if (damager.getWorld().toString().contains("DXL_Game_")) return;
+        }
+
+        if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
+            if (!guildHandler.getWorldWhitelist().contains(damager.getWorld())) return;
         }
 
         if (guildHandler.isSameGuild(damagee, damager)) {
@@ -255,6 +271,15 @@ public class EntityListener implements Listener {
         for (LivingEntity entity : event.getAffectedEntities()) {
             if (entity instanceof Player)  {
                 Player player = (Player) entity;
+                
+                if (settingsManager.getProperty(HooksSettings.DUNGEONSXL)) {
+                    if (shooter.getWorld().toString().contains("DXL_Game_")) return;
+                }
+
+                if (settingsManager.getProperty(GuildSettings.WORLDS_WHITELIST_TOGGLE)) {
+                    if (!guildHandler.getWorldWhitelist().contains(shooter.getWorld())) return;
+                }
+                
                 if (guildHandler.isSameGuild(shooter, player) && potion.getShooter() != player ) {
                     event.setCancelled(!settingsManager.getProperty(GuildSettings.GUILD_DAMAGE));
                     return;

--- a/src/main/java/me/glaremasters/guilds/tasks/GuildWarReadyTask.java
+++ b/src/main/java/me/glaremasters/guilds/tasks/GuildWarReadyTask.java
@@ -28,6 +28,7 @@ import com.google.common.base.Joiner;
 import me.glaremasters.guilds.Guilds;
 import me.glaremasters.guilds.challenges.ChallengeHandler;
 import me.glaremasters.guilds.guild.GuildChallenge;
+import me.glaremasters.guilds.guild.GuildHandler;
 import me.glaremasters.guilds.messages.Messages;
 import me.glaremasters.guilds.utils.JSONMessage;
 import org.bukkit.Bukkit;
@@ -80,6 +81,7 @@ public class GuildWarReadyTask extends BukkitRunnable {
                 cancel();
                 return;
             }
+
             // Create final list for both sides
             challengeHandler.prepareFinalList(challenge.getChallengePlayers(), challenge, "challenger");
             challengeHandler.prepareFinalList(challenge.getDefendPlayers(), challenge, "defender");

--- a/src/main/java/me/glaremasters/guilds/tasks/GuildWarReadyTask.java
+++ b/src/main/java/me/glaremasters/guilds/tasks/GuildWarReadyTask.java
@@ -28,7 +28,6 @@ import com.google.common.base.Joiner;
 import me.glaremasters.guilds.Guilds;
 import me.glaremasters.guilds.challenges.ChallengeHandler;
 import me.glaremasters.guilds.guild.GuildChallenge;
-import me.glaremasters.guilds.guild.GuildHandler;
 import me.glaremasters.guilds.messages.Messages;
 import me.glaremasters.guilds.utils.JSONMessage;
 import org.bukkit.Bukkit;
@@ -81,7 +80,6 @@ public class GuildWarReadyTask extends BukkitRunnable {
                 cancel();
                 return;
             }
-
             // Create final list for both sides
             challengeHandler.prepareFinalList(challenge.getChallengePlayers(), challenge, "challenger");
             challengeHandler.prepareFinalList(challenge.getDefendPlayers(), challenge, "defender");


### PR DESCRIPTION
The new avaitablePlayers method returns a list of online members to which players will not be added under certain conditions. In the future may be expanded.

Hook DungeonsXL. The player will not be added to avaitablePlayers if it is in the world of the DXL plugin.

Config option "world-whitelist". If enabled, players who are not in the world from the list will not be added to avaitablePlayers.

Some things have not been tested.

You can change the names / locations of methods or comments. My english is not perfect.