### PR TITLE
Implemented translatable enum value type for guild and ally chat

### DIFF
--- a/src/main/java/me/glaremasters/guilds/listeners/ChatListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/ChatListener.java
@@ -6,6 +6,7 @@ import me.glaremasters.guilds.Guilds;
 import me.glaremasters.guilds.guild.Guild;
 import me.glaremasters.guilds.guild.GuildHandler;
 import me.glaremasters.guilds.messages.Messages;
+import me.glaremasters.guilds.utils.MessageUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -72,24 +73,34 @@ public class ChatListener implements Listener {
         if (playerChatMap.containsKey(player.getUniqueId())) {
             final ChatType type = playerChatMap.remove(player.getUniqueId());
             if (type == chatType) {
-                issuer.sendInfo(Messages.CHAT__TOGGLED_OFF, "{type}", chatType.name());
+                issuer.sendInfo(Messages.CHAT__TOGGLED_OFF, "{type}", chatType.translate(player, guilds));
                 return;
             }
 
-            issuer.sendInfo(Messages.CHAT__TOGGLED_OFF, "{type}", chatType.name());
-            issuer.sendInfo(Messages.CHAT__TOGGLED_ON, "{type}", chatType.name());
+            issuer.sendInfo(Messages.CHAT__TOGGLED_OFF, "{type}", type.translate(player, guilds));
+            issuer.sendInfo(Messages.CHAT__TOGGLED_ON, "{type}", chatType.translate(player, guilds));
             playerChatMap.put(player.getUniqueId(), chatType);
             return;
         }
 
-        issuer.sendInfo(Messages.CHAT__TOGGLED_ON, "{type}", chatType.name());
+        issuer.sendInfo(Messages.CHAT__TOGGLED_ON, "{type}", chatType.translate(player, guilds));
         playerChatMap.put(player.getUniqueId(), chatType);
     }
 
 
     public enum ChatType {
-        GUILD,
-        ALLY
+        GUILD(Messages.CHAT__TYPE_GUILD),
+        ALLY(Messages.CHAT__TYPE_ALLY);
+
+        private final Messages messageKey;
+
+        ChatType(Messages messageKey) {
+            this.messageKey = messageKey;
+        }
+
+        public String translate(final Player player, final Guilds guilds) {
+            return MessageUtils.asString(player, guilds.getCommandManager(), messageKey);
+        }
     }
 
     public Map<UUID, ChatType> getPlayerChatMap() {

--- a/src/main/java/me/glaremasters/guilds/utils/MessageUtils.java
+++ b/src/main/java/me/glaremasters/guilds/utils/MessageUtils.java
@@ -1,0 +1,45 @@
+package me.glaremasters.guilds.utils;
+
+import co.aikar.commands.CommandIssuer;
+import co.aikar.commands.PaperCommandManager;
+import co.aikar.locales.MessageKeyProvider;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+public class MessageUtils {
+
+    /**
+     * Helper method to convert a message key from lang files into a String
+     *
+     * @param issuer the issuer that requested the message
+     * @param key    the key to translate
+     * @return key translated to string
+     */
+    public static String asString(@NotNull final CommandIssuer issuer, @NotNull final MessageKeyProvider key) {
+        return issuer.getManager().getLocales().getMessage(issuer, key);
+    }
+
+    /**
+     * Helper method to convert a message key from a lang file into a String
+     *
+     * @param player  the player to translate for (gets their locale if they aren't using default)
+     * @param manager the manager of the plugin
+     * @param key     the key to translate
+     * @return key translated to string
+     */
+    public static String asString(@NotNull final Player player, @NotNull final PaperCommandManager manager, @NotNull final MessageKeyProvider key) {
+        return manager.getLocales().getMessage(manager.getCommandIssuer(player), key);
+    }
+
+    /**
+     * Helper method to convert a message key from lang files into a String
+     *
+     * @param manager the manager of the plugin
+     * @param key     the key to translate
+     * @return key translated to string
+     */
+    public static String asString(@NotNull final PaperCommandManager manager, @NotNull final MessageKeyProvider key) {
+        return manager.getLocales().getMessage(manager.getCommandIssuer(Bukkit.getConsoleSender()), key);
+    }
+}

--- a/src/main/kotlin/me/glaremasters/guilds/messages/Messages.kt
+++ b/src/main/kotlin/me/glaremasters/guilds/messages/Messages.kt
@@ -142,6 +142,8 @@ enum class Messages : MessageKeyProvider {
 
     CHAT__TOGGLED_ON,
     CHAT__TOGGLED_OFF,
+    CHAT__TYPE_GUILD,
+    CHAT__TYPE_ALLY,
 
     ALLY__NONE,
     ALLY__LIST,

--- a/src/main/resources/languages/en-US.yml
+++ b/src/main/resources/languages/en-US.yml
@@ -100,6 +100,8 @@ create:
 chat:
   toggled-on: "{type} chat toggled on."
   toggled-off: "{type} chat toggled off."
+  type-guild: "Guild"
+  type-ally: "Ally"
 request:
   success: "&aYou've successfully requested an invite from {guild}"
   incoming-request: "&a{player} is requesting to join the guild. Send them an invite by doing /guild invite {player}!"


### PR DESCRIPTION
Makes the enum value types look for lang file keys to translate the type of chat being toggled. Also fixes a bug where it was saying the wrong chat type was being turned off right before being turned on when toggling across chat types without turning off the other one manually first.