### PR TITLE
event.isCancelled() test should in fact be inverted

### DIFF
--- a/src/main/java/me/glaremasters/guilds/listeners/ChatListener.java
+++ b/src/main/java/me/glaremasters/guilds/listeners/ChatListener.java
@@ -72,7 +72,7 @@ public class ChatListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST)
     public void onChatHighest(final AsyncPlayerChatEvent event) {
-        if (event.isCancelled()) { //Event should already be cancelled in Lowest Priority
+        if (!event.isCancelled()) { //Event should already be cancelled in Lowest Priority
             return;
         }
 


### PR DESCRIPTION
Turns out the `event.isCancelled()` should be inverted, as the event in the "lowest" listener is only cancelled if it is to be handled by Guilds instead of Minecraft default.