### PR TITLE
Update ChallengeHandler.java

### DIFF
--- a/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
+++ b/src/main/java/me/glaremasters/guilds/challenges/ChallengeHandler.java
@@ -277,7 +277,7 @@ public class ChallengeHandler {
         getAllPlayersAlive(challenge).forEach((key, value) -> {
             final Location location = ACFBukkitUtil.stringToLocation(value);
             final Player player = Bukkit.getPlayer(key);
-            Bukkit.getScheduler().runTaskLater(guilds, () -> player.teleport(location), 1L);
+            Bukkit.getScheduler().runTaskLater(guilds, () -> player.teleport(location), 120 * 20L);
         });
     }
 


### PR DESCRIPTION
I am added public void teleportRemaining(@NotNull GuildChallenge challenge) {
        getAllPlayersAlive(challenge).forEach((key, value) -> {
            final Location location = ACFBukkitUtil.stringToLocation(value);
            final Player player = Bukkit.getPlayer(key);
            Bukkit.getScheduler().runTaskLater(guilds, () -> player.teleport(location), 120 * 20L);
        });
    }

For cooldown before teleport. Because players can't take items after kill a player.