### PR TITLE
Fix build.gradle.kts split index error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,7 +134,7 @@ tasks {
         fun relocates(vararg dependencies: String) {
             dependencies.forEach {
                 val split = it.split(".")
-                val name = split.last()
+                val name = split[split.length - 1]
                 relocate(it, "me.glaremasters.guilds.libs.$name")
             }
         }
@@ -154,7 +154,7 @@ tasks {
         fun relocates(vararg dependencies: String) {
             dependencies.forEach {
                 val split = it.split(".")
-                val name = split.last()
+                val name = split[split.length - 1]
                 relocate(it, "me.glaremasters.guilds.libs.$name")
             }
         }


### PR DESCRIPTION
Fixes the error that states: Task with name '{dep_name}' not found in root project 'Guilds'.